### PR TITLE
tx.py: fix TypeError when splitting byte string (python3 compatibility)

### DIFF
--- a/tx.py
+++ b/tx.py
@@ -2,7 +2,6 @@
 
 from pycc1101.pycc1101 import TICC1101
 from struct import pack
-import binascii
 import time
 
 ticc1101 = TICC1101()
@@ -18,7 +17,6 @@ count = 0
 
 while True:
     data = pack('<I', count)
-    toSend = [int(binascii.hexlify(x),16) for x in data]
-    ticc1101.sendData(toSend)
+    ticc1101.sendData(list(data))
     count += 1
     time.sleep(1)


### PR DESCRIPTION
python2.7:
```python
>>> count = 12345678
>>> data = pack('<I', count)
>>> toSend = [int(binascii.hexlify(x),16) for x in data]
>>> toSend
[78, 97, 188, 0]
```

python3.8:
```python
>>> count = 12345678
>>> data = pack('<I', count)
>>> toSend = [int(binascii.hexlify(x),16) for x in data]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 1, in <listcomp>
TypeError: a bytes-like object is required, not 'int'
>>> toSend = list(data)
>>> toSend
[78, 97, 188, 0]
```